### PR TITLE
FixOneScalarInMulti-GPU

### DIFF
--- a/main.py
+++ b/main.py
@@ -274,6 +274,8 @@ def main():
             if n_gpu > 1:
                 tmp_eval_loss = tmp_eval_loss.mean() # mean() to average on multi-gpu.
                 tmp_eval_accuracy = tmp_eval_accuracy.sum()
+                tmp_h_acc = tmp_h_acc.sum()
+                tmp_m_acc = tmp_m_acc.sum()
             eval_loss += tmp_eval_loss.item()
             eval_accuracy += tmp_eval_accuracy.item()
             eval_h_acc += tmp_h_acc.item()
@@ -315,6 +317,8 @@ def main():
             if n_gpu > 1:
                 tmp_eval_loss = tmp_eval_loss.mean() # mean() to average on multi-gpu.
                 tmp_eval_accuracy = tmp_eval_accuracy.sum()
+                tmp_h_acc = tmp_h_acc.sum()
+                tmp_m_acc = tmp_m_acc.sum()
             eval_loss += tmp_eval_loss.item()
             eval_accuracy += tmp_eval_accuracy.item()
             eval_h_acc += tmp_h_acc.item()


### PR DESCRIPTION
# Current Behavior

When I run main.py in multi gpus, it comes to

``` shell
error: main.py 279 eval_h_acc += tmp_h_acc.item()
only one element tensors can be converted to Python scalars
```
# Possible Solution

as follows

More details in [issues](https://github.com/laiguokun/bert-cloth/issues/11)